### PR TITLE
Change e.message => str(e) due to deprecation warning

### DIFF
--- a/appsync/__init__.py
+++ b/appsync/__init__.py
@@ -50,10 +50,10 @@ class CatchAuthError(object):
             return request.get_response(self.app)
         except (HTTPUnauthorized, StorageAuthError), e:
             logger.debug(traceback.format_exc())
-            return HTTPUnauthorized(e.message)
+            return HTTPUnauthorized(str(e))
         except (ConnectionError, ServerError, HTTPServiceUnavailable), e:
             logger.error(traceback.format_exc())
-            return HTTPServiceUnavailable(e.message,
+            return HTTPServiceUnavailable(str(e),
                                           retry_after=self.retry_after)
         finally:
             if hasattr(request, 'cache'):

--- a/appsync/storage/sql.py
+++ b/appsync/storage/sql.py
@@ -218,7 +218,7 @@ class SQLDatabase(object):
         try:
             email = self._verifier.verify(assertion, audience)["email"]
         except (ValueError, vep.TrustError), e:
-            raise StorageAuthError(e.message)
+            raise StorageAuthError(str(e))
 
         # create the token and create a session with it
         token = gen_uuid(email, audience)

--- a/appsync/views.py
+++ b/appsync/views.py
@@ -191,7 +191,7 @@ def get_data(request):
             poll_interval = cache.get('X-Sync-Poll')
         except CacheError, e:
             # a well, nevermind then
-            logger.error(e.message)
+            logger.error(str(e))
         else:
             if poll_interval is not None:
                 request.response.headers['X-Sync-Poll'] = str(poll_interval)


### PR DESCRIPTION
This fixes DeprecationWarnings about use of e.message.  If there's a better option than str(e) just let me know...
